### PR TITLE
chore: defensive check before attaching jump cmd

### DIFF
--- a/.zsh/.zshrc
+++ b/.zsh/.zshrc
@@ -49,4 +49,6 @@ export FZF_DEFAULT_COMMAND='fd --type f --hidden --follow --exclude .git'
 ssh-add -A &> /dev/null
 
 # jump for easier dir traversal
-eval "$(jump shell)"
+if [ -x "$(command -v jump)" ]; then
+    eval "$(jump shell)"
+fi


### PR DESCRIPTION
# Context

The machine may not have `jump` binary installed. This PR makes the zshrc more defensive to the case that machine not having jump installed.